### PR TITLE
Fixed invalid brightness issue

### DIFF
--- a/lifx-api/lifx.js
+++ b/lifx-api/lifx.js
@@ -169,7 +169,7 @@ module.exports = function(RED) {
       var settings = {
         power: defaultTo(msg.payload.power, this.power),
         color: defaultTo(msg.payload.color, this.color),
-        brightness: defaultTo(msg.payload.brightness, this.brightness),
+        brightness: Number(defaultTo(msg.payload.brightness, this.brightness)),
         duration: defaultTo(msg.payload.duration, this.duration),
         infrared: defaultTo(msg.payload.infrared, this.infrared)
       };


### PR DESCRIPTION
I started getting the following error: "brightness does not have a valid value" despite definitely entering a number between 0 and 1 in the brightness field. This only started happening a few days ago, and the module was working perfectly until then, so I don't know what changed.

This is a quick and dirty fix, but it works for me. Perhaps there should be a validity check on all the config options, so that errors like this get caught before any HTTP requests are sent.